### PR TITLE
artemis_install_dir + Fix deprecations with Ansible versions >= 2.4.0 + Journal type

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Install and configure activemq artemis broker.
 | artemis_download_url | string | | Download Artemis archive url |
 | artemis_group | dictionnary | see defaults| Artemis service group |
 | artemis_user | dictionnary | see defaults | Artemis service user |
-| artemis_home | string | ```/opt``` | Artemis home |
+| artemis_install_dir | string | ```/opt``` | Artemis installation directory |
+| artemis_home | string | ```/{{ artemis_install_dir }}/apache-artemis-{{ artemis_version }}``` | Artemis home directory |
 | artemis_brokers | list | see defaults | List of brokers to install (you can install multiple instances if you want to) |
 
 ### Broker default configuration

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install and configure activemq artemis broker.
 | artemis_port_mqtt | number | 1883 | Mqtt port |
 | artemis_acceptors | list | see defaults | List of artemis acceptors for the broker (amqp, mqtt, ...) |
 | artemis_journal_type | string | NIO | Journal type |
-
+| artemis_journal_pool_files | string | 10 | Upper threshold of the journal file pool |
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Install and configure activemq artemis broker.
 | artemis_acceptors | list | see defaults | List of artemis acceptors for the broker (amqp, mqtt, ...) |
 | artemis_journal_type | string | NIO | Journal type |
 | artemis_journal_pool_files | string | 10 | Upper threshold of the journal file pool |
+| artemis_journal_buffer_timeouts | dict | {NIO: "3333333" ASYNCIO: "500000"} | Artemis defaults for journal-buffer-timeout, depending on journal-type |
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install and configure activemq artemis broker.
 | artemis_group | dictionnary | see defaults| Artemis service group |
 | artemis_user | dictionnary | see defaults | Artemis service user |
 | artemis_install_dir | string | ```/opt``` | Artemis installation directory |
-| artemis_home | string | ```/{{ artemis_install_dir }}/apache-artemis-{{ artemis_version }}``` | Artemis home directory |
+| artemis_home | string | ```{{ artemis_install_dir }}/apache-artemis-{{ artemis_version }}``` | Artemis home directory |
 | artemis_brokers | list | see defaults | List of brokers to install (you can install multiple instances if you want to) |
 
 ### Broker default configuration
@@ -31,6 +31,7 @@ Install and configure activemq artemis broker.
 | artemis_port_hornetq | number | 5445 | HornetQ port |
 | artemis_port_mqtt | number | 1883 | Mqtt port |
 | artemis_acceptors | list | see defaults | List of artemis acceptors for the broker (amqp, mqtt, ...) |
+| artemis_journal_type | string | NIO | Journal type |
 
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ artemis_port_hornetq: 5445
 artemis_port_mqtt: 1883
 
 artemis_journal_type: "NIO"
+artemis_journal_pool_files: 10
 
 artemis_acceptors:
   - name: "artemis"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,10 @@ artemis_port_mqtt: 1883
 
 artemis_journal_type: "NIO"
 artemis_journal_pool_files: 10
+artemis_journal_buffer_timeouts:
+  NIO: "3333333"
+  ASYNCIO: "500000"
+artemis_journal_buffer_timeout: "{{ artemis_journal_buffer_timeouts[artemis_journal_type] }}"
 
 artemis_acceptors:
   - name: "artemis"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ artemis_port_stomp: 61613
 artemis_port_hornetq: 5445
 artemis_port_mqtt: 1883
 
+artemis_journal_type: "NIO"
+
 artemis_acceptors:
   - name: "artemis"
     url: "tcp://{{ artemis_host }}:{{ artemis_port_artemis }}?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,8 @@ artemis_user:
   createhome: no
   system: yes
 
-artemis_home: "/opt"
+artemis_install_dir: "/opt"
+artemis_home: "{{ artemis_install_dir }}/apache-artemis-{{ artemis_version }}"
 
 artemis_brokers:
   - name: "artemis-broker"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Matthieu Rémy
   description: Install elasticstack prerequisites (repo, java, ...)
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
 
   platforms:
     - name: EL

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -36,4 +36,4 @@
   notify: "restart broker"
 
 - name: "Install broker as service"
-  include: service.yml
+  include_tasks: service.yml

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -9,7 +9,6 @@
       host: "{{ broker.host | default(artemis_host) }}"
       journal_type: "{{ broker.journal_type | default(artemis_journal_type) }}"
       journal_pool_files: "{{ broker.journal_pool_files | default(artemis_journal_pool_files) }}"
-
       acceptors: "{{ broker.acceptors | default(artemis_acceptors) }}"
 
 - name: "Check if {{ _broker.name }} already created"

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -7,6 +7,7 @@
       user: "{{ broker.user }}"
       password: "{{ broker.password }}"
       host: "{{ broker.host | default(artemis_host) }}"
+      journal_type: "{{ broker.journal_type | default(artemis_journal_type) }}"
       acceptors: "{{ broker.acceptors | default(artemis_acceptors) }}"
 
 - name: "Check if {{ _broker.name }} already created"

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -8,6 +8,8 @@
       password: "{{ broker.password }}"
       host: "{{ broker.host | default(artemis_host) }}"
       journal_type: "{{ broker.journal_type | default(artemis_journal_type) }}"
+      journal_pool_files: "{{ broker.journal_pool_files | default(artemis_journal_pool_files) }}"
+
       acceptors: "{{ broker.acceptors | default(artemis_acceptors) }}"
 
 - name: "Check if {{ _broker.name }} already created"

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -9,6 +9,7 @@
       host: "{{ broker.host | default(artemis_host) }}"
       journal_type: "{{ broker.journal_type | default(artemis_journal_type) }}"
       journal_pool_files: "{{ broker.journal_pool_files | default(artemis_journal_pool_files) }}"
+      journal_buffer_timeout: "{{ artemis_journal_buffer_timeout }}"
       acceptors: "{{ broker.acceptors | default(artemis_acceptors) }}"
 
 - name: "Check if {{ _broker.name }} already created"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: "Download and extract archive"
   unarchive:
     src: "{{ artemis_download_url }}"
-    dest: "{{ artemis_home }}"
+    dest: "{{ artemis_install_dir }}"
     remote_src: yes
     owner: "{{ artemis_user.name }}"
     group: "{{ artemis_user.group }}"
@@ -40,8 +40,8 @@
 
 - name: "Create link"
   file:
-    src: "{{ artemis_home }}/apache-artemis-{{ artemis_version }}"
-    dest: "{{ artemis_home }}/artemis"
+    src: "{{ artemis_home }}"
+    dest: "{{ artemis_install_dir }}/artemis"
     state: link
     owner: "{{ artemis_user.name }}"
     group: "{{ artemis_user.group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     group: "{{ artemis_user.group }}"
 
 - name: "Create brokers"
-  include: broker.yml
+  include_tasks: broker.yml
   with_items: "{{ artemis_brokers }}"
   loop_control:
     loop_var: broker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,9 +25,6 @@
     - "{{ artemis_home }}"
 #   - "{{ artemis_log_dir }}"
 
-- name: "Check if artemis already installed"
-  stat: path={{ artemis_home }}/apache-artemis-{{ artemis_version }}
-  register: artemis_path
 
 - name: "Download and extract archive"
   unarchive:
@@ -36,7 +33,7 @@
     remote_src: yes
     owner: "{{ artemis_user.name }}"
     group: "{{ artemis_user.group }}"
-  when: not artemis_path.stat.exists
+    creates: "{{ artemis_home }}/bin/artemis"
 
 - name: "Create link"
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,7 @@
     group: "{{ artemis_user.group }}"
   with_items:
     - "{{ artemis_home }}"
-#   - "{{ artemis_log_dir }}"
-
+    - "{{ artemis_log_dir | default([])}}"
 
 - name: "Download and extract archive"
   unarchive:

--- a/templates/artemis/etc/broker.xml
+++ b/templates/artemis/etc/broker.xml
@@ -34,7 +34,7 @@ under the License.
            MAPPED: mmap files
            NIO: Plain Java Files
        -->
-      <journal-type>NIO</journal-type>
+      <journal-type>{{ _broker.journal_type }}</journal-type>
 
       <paging-directory>./data/paging</paging-directory>
 

--- a/templates/artemis/etc/broker.xml
+++ b/templates/artemis/etc/broker.xml
@@ -48,7 +48,7 @@ under the License.
 
       <journal-min-files>2</journal-min-files>
 
-      <journal-pool-files>-1</journal-pool-files>
+      <journal-pool-files>{{ _broker.journal_pool_files }}</journal-pool-files>
 
       <!--
         You can verify the network health of a particular NIC by specifying the <network-check-NIC> element.

--- a/templates/artemis/etc/broker.xml
+++ b/templates/artemis/etc/broker.xml
@@ -84,7 +84,7 @@ under the License.
        on the current journal configuration.
        That translates as a sync write every 1000000 nanoseconds
       -->
-      <journal-buffer-timeout>1000000</journal-buffer-timeout>
+      <journal-buffer-timeout>{{ _broker.journal_buffer_timeout }}</journal-buffer-timeout>
 
 
       <!-- how often we are looking for how many bytes are being used on the disk in ms -->


### PR DESCRIPTION
1. artemis_home was configured to be /opt. The "Create direcotries" task would set artemis user as the owner for the whole /opt. Defining home as the actual home directory for the application, and separating installation directory from home is reasonable, and makes installation more straightforward.

2. include: statements are to be deprecated. Those have been replaced with include_tasks from Ansible 2.4.0, thus bump of minimium Ansible version.

3. New configurable vars:
-- Journal type
-- Journal pool files https://issues.apache.org/jira/browse/ARTEMIS-1628
-- Journal buffer timeout