### PR TITLE
Upgrading Artemis with ARTEMIS_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Install and configure activemq artemis broker.
 
 | Variable     | type | Default       | Description    |
 | ------------ | ---- |------------- | -------------- |
+| artemis_home | string | ```/opt/artemis``` (symlink to system current) | ARTEMIS_HOME in etc/artemis.profile |
 | artemis_host | string | ```0.0.0.0``` | Artemis host |
 | artemis_port_artemis | number | 61616 | Tcp port |
 | artemis_port_amqp | number | 5672| Amqp port |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for artemis
 
-artemis_version: "2.5.0"
+artemis_version: "2.6.0"
 artemis_download_url: "https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/{{ artemis_version }}/apache-artemis-{{ artemis_version }}-bin.tar.gz&action=download"
 
 artemis_group:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ artemis_user:
 
 artemis_install_dir: "/opt"
 artemis_home: "{{ artemis_install_dir }}/apache-artemis-{{ artemis_version }}"
+artemis_home_symlink: "{{ artemis_install_dir }}/artemis"
 
 artemis_brokers:
   - name: "artemis-broker"

--- a/tasks/instance/configure.yml
+++ b/tasks/instance/configure.yml
@@ -15,5 +15,5 @@
   lineinfile:
     dest: "{{ _broker.path }}/{{ _broker.name }}/etc/artemis.profile"
     regexp: "^ARTEMIS_HOME"
-    line: "ARTEMIS_HOME='{{ artemis_home_symlink }}'"
+    line: "ARTEMIS_HOME='{{ _broker.artemis_home }}'"
   notify: "restart broker"

--- a/tasks/instance/configure.yml
+++ b/tasks/instance/configure.yml
@@ -10,3 +10,10 @@
     src: "artemis/etc/bootstrap.xml"
     dest: "{{ _broker.path }}/{{ _broker.name }}/etc/bootstrap.xml"
   notify: "restart broker"
+
+- name: "Ensure ARTEMIS_HOME is correct in artemis.profile"
+  lineinfile:
+    dest: "{{ _broker.path }}/{{ _broker.name }}/etc/artemis.profile"
+    regexp: "^ARTEMIS_HOME"
+    line: "ARTEMIS_HOME='{{ artemis_home_symlink }}'"
+  notify: "restart broker"

--- a/tasks/instance/instance.yml
+++ b/tasks/instance/instance.yml
@@ -2,6 +2,7 @@
 - name: "Init broker with default values."
   set_fact:
     _broker:
+      artemis_home: "{{ broker.artemis_home | default(artemis_home_symlink) }}"
       name: "{{ broker.name }}"
       path: "{{ broker.path }}"
       user: "{{ broker.user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: "Create link"
   file:
     src: "{{ artemis_home }}"
-    dest: "{{ artemis_install_dir }}/artemis"
+    dest: "{{ artemis_home_symlink }}"
     state: link
     owner: "{{ artemis_user.name }}"
     group: "{{ artemis_user.group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
     owner: "{{ artemis_user.name }}"
     group: "{{ artemis_user.group }}"
     creates: "{{ artemis_home }}/bin/artemis"
+  notify: restart broker
 
 - name: "Create link"
   file:


### PR DESCRIPTION
As described here https://activemq.apache.org/artemis/docs/latest/upgrading.html, in most cases Artemis can be upgraded just by pointing ARTEMIS_HOME to new version. If we use the symlinked version as the default, we can smoothly upgrade Artemis by just changing `artemis_version`.